### PR TITLE
Fix snapshot kind default path assignment if explicitely disabled

### DIFF
--- a/lib/pages.js
+++ b/lib/pages.js
@@ -242,6 +242,9 @@ const takeSnapshot = async function(page, options = {}) {
   if (options.path !== undefined) {
     fs.mkdirSync(options.path, { recursive: true });
     for (kind in SNAPSHOT_DEFAULT_FILE_NAMES) {
+      if (options[kind] !== undefined && options[kind] === false) {
+        continue;
+      }
       options[kind] = Object.assign({}, options[kind]); // ensure object
       if (options[kind].path === undefined) {
         options[kind].path =


### PR DESCRIPTION
**Scenario:**
Override default `options.path` but disable viewport  with `options.viewport = false`.
This will try to create default paths for each kind of snapshot which will override the `viewport: false` with a new object `{ path: ... }` and reenable the viewport snapshot.

```js
// ...

optionsSnapshot = Object.assign(
  { path: path.join(outputDirectory, "snapshot", "extra") }, // custom base path
  { viewport: false }, // disable one kind of snapshot
  scriptOptions[SCRIPT_OPTIONS_SNAPSHOT] // default stuff
);

// ...

await pages.takeSnapshot(page, optionsSnapshot);
```